### PR TITLE
fix: Add getRetiredPools() instead of getRewardAddressesOfRetiredPools to fetcher interface

### DIFF
--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/DepositsCalculation.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/DepositsCalculation.java
@@ -1,20 +1,23 @@
 package org.cardanofoundation.rewards.calculation;
 
-import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
+import org.cardanofoundation.rewards.calculation.domain.RetiredPool;
 
 import java.math.BigInteger;
-import static org.cardanofoundation.rewards.calculation.util.BigNumberUtils.multiply;
+import java.util.Set;
 
 public class DepositsCalculation {
 
     public static BigInteger calculateDepositsInEpoch(BigInteger depositsInPreviousEpoch,
                                                       BigInteger transactionDepositsInEpoch,
-                                                      int retiredPoolsInEpoch,
-                                                      NetworkConfig networkConfig) {
+                                                      Set<RetiredPool> retiredPoolsInEpoch) {
         BigInteger deposits = BigInteger.ZERO;
         deposits = deposits.add(transactionDepositsInEpoch);
-        deposits = deposits.subtract(
-                    multiply(retiredPoolsInEpoch, networkConfig.getPoolDepositInLovelace()));
+
+        //add deposits of retired pools
+        var refundAmount = retiredPoolsInEpoch.stream()
+                .reduce(BigInteger.ZERO, (sum, retiredPool) -> sum.add(retiredPool.getDepositAmount()), BigInteger::add);
+
+        deposits = deposits.subtract(refundAmount);
         return depositsInPreviousEpoch.add(deposits);
     }
 }

--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/domain/RetiredPool.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/domain/RetiredPool.java
@@ -1,0 +1,30 @@
+package org.cardanofoundation.rewards.calculation.domain;
+
+import lombok.*;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RetiredPool {
+    private String poolId;
+    private String rewardAddress;
+    private BigInteger depositAmount;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RetiredPool that = (RetiredPool) o;
+        return Objects.equals(poolId, that.poolId) && Objects.equals(rewardAddress, that.rewardAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(poolId, rewardAddress);
+    }
+}

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/DepositsValidation.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/DepositsValidation.java
@@ -1,10 +1,12 @@
 package org.cardanofoundation.rewards.validation;
 
 import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
+import org.cardanofoundation.rewards.calculation.domain.RetiredPool;
 import org.cardanofoundation.rewards.validation.data.provider.DataProvider;
 import org.cardanofoundation.rewards.calculation.domain.AdaPots;
 import java.math.BigInteger;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.cardanofoundation.rewards.calculation.DepositsCalculation.calculateDepositsInEpoch;
 
@@ -14,14 +16,14 @@ public class DepositsValidation {
         AdaPots adaPots = dataProvider.getAdaPotsForEpoch(epoch);
         BigInteger depositsInPreviousEpoch = adaPots.getDeposits();
         BigInteger transactionDepositsInEpoch = BigInteger.ZERO;
-        HashSet<String> retiredPoolsInEpoch = new HashSet<>();
+        Set<RetiredPool> retiredPoolsInEpoch = new HashSet<>();
 
-        if (epoch > 207) {
+        if (epoch >= networkConfig.getShelleyStartEpoch()) {
             transactionDepositsInEpoch = dataProvider.getTransactionDepositsInEpoch(epoch);
-            retiredPoolsInEpoch = dataProvider.getRewardAddressesOfRetiredPoolsInEpoch(epoch + 1);
+            retiredPoolsInEpoch = dataProvider.getRetiredPoolsInEpoch(epoch + 1);
         }
 
         return calculateDepositsInEpoch(depositsInPreviousEpoch,
-                transactionDepositsInEpoch, retiredPoolsInEpoch.size(), networkConfig);
+                transactionDepositsInEpoch, retiredPoolsInEpoch);
     }
 }

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/EpochValidation.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/EpochValidation.java
@@ -104,7 +104,7 @@ public class EpochValidation {
 
             epochCalculationResult = EpochCalculation.calculateEpochRewardPots(
                     epoch, epochValidationInput.getReservesOfPreviousEpoch(),
-                    epochValidationInput.getTreasuryOfPreviousEpoch(), protocolParameters, epochInfo, epochValidationInput.getRewardAddressesOfRetiredPoolsInEpoch(),
+                    epochValidationInput.getTreasuryOfPreviousEpoch(), protocolParameters, epochInfo, epochValidationInput.getRetiredPools(),
                     epochValidationInput.getDeregisteredAccounts(),
                     new ArrayList<>(epochValidationInput.getMirCertificates()),
                     new ArrayList<>(poolIds),
@@ -121,7 +121,10 @@ public class EpochValidation {
             AdaPots adaPotsForPreviousEpoch = dataProvider.getAdaPotsForEpoch(epoch - 1);
             ProtocolParameters protocolParameters = dataProvider.getProtocolParametersForEpoch(epoch - 2);
             Epoch epochInfo = dataProvider.getEpochInfo(epoch - 2, networkConfig);
-            HashSet<String> rewardAddressesOfRetiredPoolsInEpoch = dataProvider.getRewardAddressesOfRetiredPoolsInEpoch(epoch);
+
+            Set<RetiredPool> retiredPoolsInEpoch = dataProvider.getRetiredPoolsInEpoch(epoch);
+            Set<String> rewardAddressesOfRetiredPoolsInEpoch = retiredPoolsInEpoch.stream().map(RetiredPool::getRewardAddress).collect(Collectors.toSet());
+
             List<MirCertificate> mirCertificates = dataProvider.getMirCertificatesInEpoch(epoch - 1);
             List<PoolBlock> blocksMadeByPoolsInEpoch = dataProvider.getBlocksMadeByPoolsInEpoch(epoch - 2);
             List<String> poolIds = blocksMadeByPoolsInEpoch.stream().map(PoolBlock::getPoolId).distinct().toList();
@@ -167,7 +170,7 @@ public class EpochValidation {
 
             start = System.currentTimeMillis();
             epochCalculationResult = EpochCalculation.calculateEpochRewardPots(
-                    epoch, adaPotsForPreviousEpoch.getReserves(), adaPotsForPreviousEpoch.getTreasury(), protocolParameters, epochInfo, rewardAddressesOfRetiredPoolsInEpoch, deregisteredAccounts,
+                    epoch, adaPotsForPreviousEpoch.getReserves(), adaPotsForPreviousEpoch.getTreasury(), protocolParameters, epochInfo, retiredPoolsInEpoch, deregisteredAccounts,
                     mirCertificates, poolIds, poolStates, lateDeregisteredAccounts,
                     registeredAccountsSinceLastEpoch, registeredAccountsUntilNow, sharedPoolRewardAddressesWithoutReward,
                     deregisteredAccountsOnEpochBoundary, networkConfig);

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/TreasuryValidation.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/TreasuryValidation.java
@@ -10,6 +10,7 @@ import org.cardanofoundation.rewards.validation.domain.TreasuryValidationResult;
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TreasuryValidation {
@@ -49,7 +50,7 @@ public class TreasuryValidation {
       }
 
       treasuryCalculationResult = TreasuryCalculation.calculateTreasuryInEpoch(epoch, protocolParameters, adaPotsForPreviousEpoch, epochInfo,
-              epochValidationInput.getRewardAddressesOfRetiredPoolsInEpoch(),
+              epochValidationInput.getRetiredPools(),
               epochValidationInput.getMirCertificates().stream().toList(),
               epochValidationInput.getDeregisteredAccountsOnEpochBoundary(),
               epochValidationInput.getRegisteredAccountsUntilNow(), BigInteger.ZERO, networkConfig);
@@ -57,7 +58,8 @@ public class TreasuryValidation {
       AdaPots adaPotsForPreviousEpoch = dataProvider.getAdaPotsForEpoch(epoch - 1);
       ProtocolParameters protocolParameters = dataProvider.getProtocolParametersForEpoch(epoch - 2);
       Epoch epochInfo = dataProvider.getEpochInfo(epoch - 2, networkConfig);
-      HashSet<String> rewardAddressesOfRetiredPoolsInEpoch = dataProvider.getRewardAddressesOfRetiredPoolsInEpoch(epoch);
+      Set<RetiredPool> retiredPools = dataProvider.getRetiredPoolsInEpoch(epoch);
+      Set<String> rewardAddressesOfRetiredPoolsInEpoch = retiredPools.stream().map(RetiredPool::getRewardAddress).collect(Collectors.toSet());
       List<MirCertificate> mirCertificates = dataProvider.getMirCertificatesInEpoch(epoch - 1);
       List<PoolBlock> blocksMadeByPoolsInEpoch = dataProvider.getBlocksMadeByPoolsInEpoch(epoch - 2);
       List<PoolState> poolHistories = dataProvider.getHistoryOfAllPoolsInEpoch(epoch - 2, blocksMadeByPoolsInEpoch);
@@ -66,7 +68,7 @@ public class TreasuryValidation {
       HashSet<String> poolRewardAddresses = poolHistories.stream().map(PoolState::getRewardAddress).collect(Collectors.toCollection(HashSet::new));
       poolRewardAddresses.addAll(rewardAddressesOfRetiredPoolsInEpoch);
       HashSet<String> registeredAccountsUntilNow = dataProvider.getRegisteredAccountsUntilNow(epoch, poolRewardAddresses, networkConfig.getRandomnessStabilisationWindow());
-      treasuryCalculationResult = TreasuryCalculation.calculateTreasuryInEpoch(epoch, protocolParameters, adaPotsForPreviousEpoch, epochInfo, rewardAddressesOfRetiredPoolsInEpoch, mirCertificates, deregisteredAccountsOnEpochBoundary, registeredAccountsUntilNow, BigInteger.ZERO, networkConfig);
+      treasuryCalculationResult = TreasuryCalculation.calculateTreasuryInEpoch(epoch, protocolParameters, adaPotsForPreviousEpoch, epochInfo, retiredPools, mirCertificates, deregisteredAccountsOnEpochBoundary, registeredAccountsUntilNow, BigInteger.ZERO, networkConfig);
     }
 
     TreasuryValidationResult treasuryValidationResult = TreasuryValidationResult.fromTreasuryCalculationResult(treasuryCalculationResult);

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/data/fetcher/DbSyncDataFetcher.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/data/fetcher/DbSyncDataFetcher.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -85,7 +86,10 @@ public class DbSyncDataFetcher implements DataFetcher {
         HashSet<String> deregisteredAccounts;
         HashSet<String> deregisteredAccountsOnEpochBoundary;
         HashSet<String> lateDeregisteredAccounts = new HashSet<>();
-        HashSet<String> rewardAddressesOfRetiredPoolsInEpoch = dbSyncDataProvider.getRewardAddressesOfRetiredPoolsInEpoch(epoch);
+        Set<RetiredPool> retiredPools = new HashSet<>();
+        retiredPools = dbSyncDataProvider.getRetiredPoolsInEpoch(epoch);
+        Set<String> rewardAddressesOfRetiredPoolsInEpoch = retiredPools.stream().map(RetiredPool::getRewardAddress).collect(Collectors.toSet());
+
         if (epoch - 2 < networkConfig.getVasilHardforkEpoch()) {
             deregisteredAccounts = dbSyncDataProvider.getDeregisteredAccountsInEpoch(epoch - 1, networkConfig.getRandomnessStabilisationWindow());
             deregisteredAccountsOnEpochBoundary = dbSyncDataProvider.getDeregisteredAccountsInEpoch(epoch - 1, networkConfig.getExpectedSlotsPerEpoch());
@@ -145,7 +149,7 @@ public class DbSyncDataFetcher implements DataFetcher {
                 .blockCount(blockCount)
                 .activeStake(activeStake)
                 .nonOBFTBlockCount(nonOBFTBlockCount)
-                .rewardAddressesOfRetiredPoolsInEpoch(rewardAddressesOfRetiredPoolsInEpoch)
+                .retiredPools(retiredPools)
                 .deregisteredAccounts(deregisteredAccounts)
                 .lateDeregisteredAccounts(lateDeregisteredAccounts)
                 .registeredAccountsSinceLastEpoch(registeredAccountsSinceLastEpoch)

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/DataProvider.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/DataProvider.java
@@ -7,6 +7,7 @@ import org.cardanofoundation.rewards.validation.domain.PoolReward;
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public interface DataProvider {
 
@@ -19,7 +20,7 @@ public interface DataProvider {
     public List<PoolState> getHistoryOfAllPoolsInEpoch(int epoch, List<PoolBlock> blocksMadeByPoolsInEpoch);
     public PoolState getPoolHistory(String poolId, int epoch);
 
-    public HashSet<String> getRewardAddressesOfRetiredPoolsInEpoch(int epoch);
+    public Set<RetiredPool> getRetiredPoolsInEpoch(int epoch);
 
     public List<MirCertificate> getMirCertificatesInEpoch(int epoch);
 

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/DbSyncDataProvider.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/DbSyncDataProvider.java
@@ -18,6 +18,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -253,9 +254,9 @@ public class DbSyncDataProvider implements DataProvider {
     }
 
     @Override
-    public HashSet<String> getRewardAddressesOfRetiredPoolsInEpoch(int epoch) {
+    public Set<RetiredPool> getRetiredPoolsInEpoch(int epoch) {
         List<DbSyncPoolRetirement> poolDeregistrations = dbSyncPoolRetirementRepository.getPoolRetirementsByEpoch(epoch);
-        HashSet<String> rewardAddressesOfRetiredPools = new HashSet<>();
+        Set<RetiredPool> retiredPools = new HashSet<>();
 
         for (DbSyncPoolRetirement poolDeregistration : poolDeregistrations) {
             boolean poolDeregistrationLaterInEpoch = poolDeregistrations.stream().anyMatch(
@@ -282,11 +283,13 @@ public class DbSyncDataProvider implements DataProvider {
                 }
 
                 DbSyncPoolUpdate dbSyncPoolUpdate = dbSyncPoolUpdateRepository.findLatestUpdateInEpoch(poolDeregistration.getPool().getBech32PoolId(), epoch);
-                rewardAddressesOfRetiredPools.add(dbSyncPoolUpdate.getStakeAddress().getView());
+                var retiredPool = new RetiredPool(dbSyncPoolUpdate.getPool().getBech32PoolId(), dbSyncPoolUpdate.getStakeAddress().getView(),
+                        dbSyncPoolUpdate.getDeposit());
+                retiredPools.add(retiredPool);
             }
         }
 
-        return rewardAddressesOfRetiredPools;
+        return retiredPools;
     }
 
     @Override

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/JsonDataProvider.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/JsonDataProvider.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -121,7 +122,7 @@ public class JsonDataProvider implements DataProvider {
     }
 
     @Override
-    public HashSet<String> getRewardAddressesOfRetiredPoolsInEpoch(int epoch) {
+    public Set<RetiredPool> getRetiredPoolsInEpoch(int epoch) {
         try {
             loadEpochValidationInput(epoch);
         } catch (IOException e) {
@@ -129,7 +130,7 @@ public class JsonDataProvider implements DataProvider {
             return null;
         }
 
-        return epochValidationInput.getRewardAddressesOfRetiredPoolsInEpoch();
+        return epochValidationInput.getRetiredPools();
     }
 
     @Override

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/KoiosDataProvider.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/data/provider/KoiosDataProvider.java
@@ -1,5 +1,6 @@
 package org.cardanofoundation.rewards.validation.data.provider;
 
+import com.bloxbean.cardano.client.common.ADAConversionUtil;
 import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
 import org.cardanofoundation.rewards.calculation.domain.*;
@@ -20,9 +21,8 @@ import rest.koios.client.backend.factory.options.filters.Filter;
 import rest.koios.client.backend.factory.options.filters.FilterType;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -118,9 +118,7 @@ public class KoiosDataProvider implements DataProvider {
     }
 
     @Override
-    public HashSet<String> getRewardAddressesOfRetiredPoolsInEpoch(int epoch) {
-        HashSet<String> rewardAddressesOfRetiredPools = new HashSet<>();
-
+    public Set<RetiredPool> getRetiredPoolsInEpoch(int epoch) {
         // TODO: It seems as this is not a sufficient method to get the retired pools
         try {
             List<PoolUpdate> poolUpdateList = koiosBackendService.getPoolService().getPoolUpdates(Options.builder()
@@ -131,12 +129,14 @@ public class KoiosDataProvider implements DataProvider {
 
             if (poolUpdateList == null) return new HashSet<>();
 
-            rewardAddressesOfRetiredPools.addAll(poolUpdateList.stream().map(PoolUpdate::getRewardAddr).toList());
+            return poolUpdateList.stream()
+                            .map(poolUpdate -> new RetiredPool(poolUpdate.getPoolIdBech32(), poolUpdate.getRewardAddr(), ADAConversionUtil.adaToLovelace(500)))
+                                    .collect(Collectors.toSet());
         } catch (ApiException e) {
             e.printStackTrace();
         }
 
-        return rewardAddressesOfRetiredPools;
+        return Collections.emptySet();
     }
 
     @Override

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/domain/EpochValidationInput.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/domain/EpochValidationInput.java
@@ -1,5 +1,6 @@
 package org.cardanofoundation.rewards.validation.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 import org.cardanofoundation.rewards.calculation.domain.MirCertificate;
 import org.cardanofoundation.rewards.calculation.domain.PoolState;
@@ -15,6 +16,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EpochValidationInput {
     private int epoch;
 

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/domain/EpochValidationInput.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/domain/EpochValidationInput.java
@@ -3,10 +3,12 @@ package org.cardanofoundation.rewards.validation.domain;
 import lombok.*;
 import org.cardanofoundation.rewards.calculation.domain.MirCertificate;
 import org.cardanofoundation.rewards.calculation.domain.PoolState;
+import org.cardanofoundation.rewards.calculation.domain.RetiredPool;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -30,7 +32,7 @@ public class EpochValidationInput {
     private BigInteger activeStake;
     private int nonOBFTBlockCount;
 
-    private HashSet<String> rewardAddressesOfRetiredPoolsInEpoch;
+    private Set<RetiredPool> retiredPools;
     private HashSet<String> deregisteredAccounts;
     private HashSet<String> lateDeregisteredAccounts;
     private HashSet<String> registeredAccountsSinceLastEpoch;

--- a/validation/src/main/java/org/cardanofoundation/rewards/validation/entity/dbsync/DbSyncPoolUpdate.java
+++ b/validation/src/main/java/org/cardanofoundation/rewards/validation/entity/dbsync/DbSyncPoolUpdate.java
@@ -31,6 +31,9 @@ public class DbSyncPoolUpdate {
     @Column(name = "fixed_cost")
     private BigInteger fixedCost;
 
+    @Column(name = "deposit")
+    private BigInteger deposit;
+
     @ManyToOne
     @JoinColumn(name = "registered_tx_id", nullable = false,
             foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))

--- a/validation/src/test/java/org/cardanofoundation/rewards/validation/data/provider/DbSyncDataProviderTest.java
+++ b/validation/src/test/java/org/cardanofoundation/rewards/validation/data/provider/DbSyncDataProviderTest.java
@@ -14,8 +14,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -100,10 +100,10 @@ public class DbSyncDataProviderTest {
     }
 
     @Test
-    public void testGetRewardAddressesOfRetiredPoolsInEpoch218() {
+    public void testGetRetiredPoolsInEpoch218() {
         int epoch = 218;
-        HashSet<String> rewardAddressesOfRetiredPoolsInEpoch = dbSyncDataProvider.getRewardAddressesOfRetiredPoolsInEpoch(epoch);
+        Set<RetiredPool> retiredPools = dbSyncDataProvider.getRetiredPoolsInEpoch(epoch);
 
-        Assertions.assertEquals(7, rewardAddressesOfRetiredPoolsInEpoch.size());
+        Assertions.assertEquals(7, retiredPools.size());
     }
 }


### PR DESCRIPTION
- To fix incorrect refund amount during pool retirement when same reward address is used in multiple retired pools