### PR TITLE
fix: Fix rounding error in reserves in Preview epoch 372

### DIFF
--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/EpochCalculation.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/EpochCalculation.java
@@ -65,7 +65,7 @@ public class EpochCalculation {
 
         if (epochInfo != null) {
             activeStakeInEpoch = epochInfo.getActiveStake();
-            totalFeesForCurrentEpoch = epochInfo.getFees();
+            totalFeesForCurrentEpoch = epochInfo.getFees() != null? epochInfo.getFees(): BigInteger.ZERO;
             totalBlocksInEpoch = epochInfo.getBlockCount();
             if (isLower(decentralizationParameter, BigDecimal.valueOf(0.8)) && isHigher(decentralizationParameter, BigDecimal.ZERO)) {
                 totalBlocksInEpoch = epochInfo.getNonOBFTBlockCount();

--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/PoolRewardsCalculation.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/PoolRewardsCalculation.java
@@ -1,16 +1,15 @@
 package org.cardanofoundation.rewards.calculation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
 import org.cardanofoundation.rewards.calculation.domain.*;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.cardanofoundation.rewards.calculation.util.BigNumberUtils.*;
-import static org.cardanofoundation.rewards.calculation.util.BigNumberUtils.divide;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class PoolRewardsCalculation {
@@ -97,14 +96,14 @@ public class PoolRewardsCalculation {
      * This method calculates the pool operator reward regarding the formula described
      * in the shelly-ledger.pdf p. 61, figure 47
      */
-    public static BigInteger calculateLeaderReward(BigInteger poolReward, double margin, BigInteger poolCost,
+    public static BigInteger calculateLeaderReward(BigInteger poolReward, BigDecimal margin, BigInteger poolCost,
                                                    BigDecimal relativeOwnerStake, BigDecimal relativeStakeOfPool) {
         if (isLowerOrEquals(poolReward, poolCost)) {
             return poolReward;
         }
 
         return add(poolCost, floor(multiply(subtract(poolReward, poolCost),
-                add(margin, multiply((1 - margin), divide(relativeOwnerStake, relativeStakeOfPool))))));
+                add(margin, multiply(BigDecimal.ONE.subtract(margin), divide(relativeOwnerStake, relativeStakeOfPool))))));
     }
 
     /*
@@ -113,7 +112,7 @@ public class PoolRewardsCalculation {
      *
      * See Haskell implementation: https://github.com/input-output-hk/cardano-ledger/blob/aed5dde9cd1096cfc2e255879cd617c0d64f8d9d/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs#L117
      */
-    public static BigInteger calculateMemberReward(BigInteger poolReward, double margin, BigInteger poolCost,
+    public static BigInteger calculateMemberReward(BigInteger poolReward, BigDecimal margin, BigInteger poolCost,
                                                    BigDecimal relativeMemberStake, BigDecimal relativeStakeOfPool) {
         if (isLowerOrEquals(poolReward, poolCost)) {
             return BigInteger.ZERO;
@@ -156,11 +155,11 @@ public class PoolRewardsCalculation {
 
         final BigInteger poolStake = poolStateCurrentEpoch.getActiveStake();
         final BigInteger poolPledge = poolStateCurrentEpoch.getPledge();
-        final double poolMargin = poolStateCurrentEpoch.getMargin();
+        final BigDecimal poolMargin = BigDecimal.valueOf(poolStateCurrentEpoch.getMargin());
         final BigInteger poolFixedCost = poolStateCurrentEpoch.getFixedCost();
         final int blocksPoolHasMinted = poolStateCurrentEpoch.getBlockCount();
 
-        poolRewardCalculationResult.setPoolMargin(poolMargin);
+        poolRewardCalculationResult.setPoolMargin(poolStateCurrentEpoch.getMargin());
         poolRewardCalculationResult.setPoolCost(poolFixedCost);
         poolRewardCalculationResult.setRewardAddress(poolStateCurrentEpoch.getRewardAddress());
 


### PR DESCRIPTION
 - Convert poolMargin from double to BigDecimal to fix rounding issue in preview 
    (1 lovelace diff in preview epoch 372 where margin = 99.99%)
 - If total fee is null, set it to 0
 - Verified for both Preprod and Preview networks 