### PR TITLE
fix(calculation): use exact rational arithmetic for reward pots

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           java-version: '18'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}

--- a/calculation/.flattened-pom.xml
+++ b/calculation/.flattened-pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.cardanofoundation</groupId>
   <artifactId>cf-rewards-calculation</artifactId>
-  <version>0.11.1</version>
+  <version>1.0.1</version>
   <name>cardano-reward-calculation</name>
   <description>This project aims to be a cardano reward calculation, java formula implementation and edge case
         documentation</description>
@@ -36,25 +36,24 @@
     <url>https://github.com/cardano-foundation/cf-java-rewards-calculation/issues</url>
   </issueManagement>
   <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
   <properties>
     <version.lombok>1.18.30</version.lombok>
+    <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
     <version.flatten-maven-plugin>1.2.7</version.flatten-maven-plugin>
     <version.java>17</version.java>
     <version.slf4j>2.0.12</version.slf4j>
-    <maven.compiler.source>17</maven.compiler.source>
     <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
     <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
     <version.maven-site-plugin>4.0.0-M2</version.maven-site-plugin>
+    <version.central-publishing-plugin>0.9.0</version.central-publishing-plugin>
+    <version.junit-jupiter>5.10.2</version.junit-jupiter>
     <version.maven-project-info-reports-plugin>3.3.0</version.maven-project-info-reports-plugin>
   </properties>
   <dependencies>
@@ -79,6 +78,12 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-javadoc-plugin</artifactId>
       <version>${version.maven-javadoc-plugin}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -124,6 +129,10 @@
           <tagNameFormat>@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -131,6 +140,18 @@
       <id>ci-cd</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.central-publishing-plugin}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+              <deploymentName>${project.groupId}:${project.artifactId}-${project.version}</deploymentName>
+            </configuration>
+          </plugin>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>3.1.0</version>

--- a/calculation/pom.xml
+++ b/calculation/pom.xml
@@ -52,6 +52,8 @@
         <version.java>17</version.java>
         <version.lombok>1.18.30</version.lombok>
         <version.slf4j>2.0.12</version.slf4j>
+        <version.junit-jupiter>5.10.2</version.junit-jupiter>
+        <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
         <version.maven-site-plugin>4.0.0-M2</version.maven-site-plugin>
         <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
         <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
@@ -92,6 +94,12 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>${version.maven-javadoc-plugin}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${version.junit-jupiter}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -202,6 +210,11 @@
                     <scmCommentPrefix>[ci skip]</scmCommentPrefix>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.maven-surefire-plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/calculation/pom.xml
+++ b/calculation/pom.xml
@@ -59,17 +59,14 @@
         <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
         <version.flatten-maven-plugin>1.2.7</version.flatten-maven-plugin>
         <version.maven-project-info-reports-plugin>3.3.0</version.maven-project-info-reports-plugin>
+        <version.central-publishing-plugin>0.9.0</version.central-publishing-plugin>
     </properties>
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
     </distributionManagement>
 
     <dependencies>
@@ -108,6 +105,18 @@
             <id>ci-cd</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${version.central-publishing-plugin}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <deploymentName>${project.groupId}:${project.artifactId}-${project.version}</deploymentName>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/EpochCalculation.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/EpochCalculation.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.rewards.calculation;
 import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
 import org.cardanofoundation.rewards.calculation.domain.*;
 import org.cardanofoundation.rewards.calculation.enums.MirPot;
+import org.cardanofoundation.rewards.calculation.util.Ratio;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -76,7 +77,7 @@ public class EpochCalculation {
         final BigInteger rewardPot = TreasuryCalculation.calculateTotalRewardPotWithEta(
                 monetaryExpandRate, totalBlocksInEpoch, decentralizationParameter, reserveInPreviousEpoch, totalFeesForCurrentEpoch, networkConfig);
 
-        final BigInteger treasuryCut = multiplyAndFloor(rewardPot, treasuryGrowthRate);
+        final BigInteger treasuryCut = Ratio.from(treasuryGrowthRate).multiplyAndFloor(rewardPot);
         BigInteger treasuryForCurrentEpoch = treasuryInPreviousEpoch.add(treasuryCut);
         final BigInteger stakePoolRewardsPot = rewardPot.subtract(treasuryCut);
 

--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/TreasuryCalculation.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/TreasuryCalculation.java
@@ -3,10 +3,10 @@ package org.cardanofoundation.rewards.calculation;
 import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
 import org.cardanofoundation.rewards.calculation.domain.*;
 import org.cardanofoundation.rewards.calculation.enums.MirPot;
+import org.cardanofoundation.rewards.calculation.util.Ratio;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.MathContext;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +58,7 @@ public class TreasuryCalculation {
     final BigInteger totalRewardPot = calculateTotalRewardPotWithEta(
             monetaryExpandRate, totalBlocksInEpoch, decentralizationParameter, reserveInPreviousEpoch, totalFeesForCurrentEpoch, networkConfig);
 
-    final BigInteger treasuryCut = multiplyAndFloor(totalRewardPot, treasuryGrowthRate);
+    final BigInteger treasuryCut = Ratio.from(treasuryGrowthRate).multiplyAndFloor(totalRewardPot);
     BigInteger treasuryForCurrentEpoch = treasuryInPreviousEpoch.add(treasuryCut);
 
     var rewardAddressesOfRetiredPools = retiredPools.stream().map(RetiredPool::getRewardAddress).collect(Collectors.toSet());
@@ -98,11 +98,12 @@ public class TreasuryCalculation {
    *
    * rewards(e) = floor(monetary_expand_rate * eta * reserve(e - 1) + fee(e - 1))
    * rewards(e) = 0, if e < 209
-   */
+  */
   public static BigInteger calculateTotalRewardPotWithEta(BigDecimal monetaryExpandRate, int totalBlocksInEpochByPools,
                                                           BigDecimal decentralizationParameter, BigInteger reserve, BigInteger fee, NetworkConfig networkConfig) {
-    BigDecimal eta = calculateEta(totalBlocksInEpochByPools, decentralizationParameter, networkConfig);
-    return multiplyAndFloor(reserve, monetaryExpandRate, eta).add(fee);
+    Ratio rho = Ratio.from(monetaryExpandRate);
+    Ratio eta = calculateEtaRatio(totalBlocksInEpochByPools, decentralizationParameter, networkConfig);
+    return rho.multiply(eta).multiplyAndFloor(reserve).add(fee);
   }
 
   /*
@@ -114,28 +115,40 @@ public class TreasuryCalculation {
   *
   * See: https://github.com/input-output-hk/cardano-ledger/commit/c4f10d286faadcec9e4437411bce9c6c3b6e51c2
   */
-  private static BigDecimal calculateEta(int totalBlocksInEpochByPools, BigDecimal decentralizationParameter, NetworkConfig networkConfig) {
+  private static Ratio calculateEtaRatio(int totalBlocksInEpochByPools, BigDecimal decentralizationParameter, NetworkConfig networkConfig) {
     // shelley-delegation.pdf 5.4.3
 
     BigDecimal decentralisationThreshold = new BigDecimal("0.8");
     if (decentralizationParameter.compareTo(decentralisationThreshold) >= 0) {
-      return BigDecimal.ONE;
+      return Ratio.ONE;
     }
 
     // The number of expected blocks will be the number of slots per epoch times the active slots coefficient
-    BigDecimal activeSlotsCoeff = BigDecimal.valueOf(networkConfig.getActiveSlotCoefficient()); // See: Non-Updatable Parameters: https://cips.cardano.org/cips/cip9/
+    Ratio activeSlotsCoeff = Ratio.from(BigDecimal.valueOf(networkConfig.getActiveSlotCoefficient())); // See: Non-Updatable Parameters: https://cips.cardano.org/cips/cip9/
 
     // decentralizationParameter is the proportion of blocks that are expected to be produced by stake pools
     // instead of the OBFT (Ouroboros Byzantine Fault Tolerance) nodes. It was introduced close before the Shelley era:
     // https://github.com/input-output-hk/cardano-ledger/commit/c4f10d286faadcec9e4437411bce9c6c3b6e51c2
-    BigDecimal expectedBlocksInNonOBFTSlots = new BigDecimal(networkConfig.getExpectedSlotsPerEpoch())
-            .multiply(activeSlotsCoeff).multiply(BigDecimal.ONE.subtract(decentralizationParameter));
+    Ratio expectedBlocksInNonOBFTSlots = Ratio.of(BigInteger.valueOf(networkConfig.getExpectedSlotsPerEpoch()))
+            .multiply(activeSlotsCoeff)
+            .multiply(Ratio.ONE.subtract(Ratio.from(decentralizationParameter)));
+    BigInteger expectedBlocks = expectedBlocksInNonOBFTSlots.floor();
+    if (expectedBlocks.signum() <= 0) {
+      throw new IllegalArgumentException("Expected blocks must be positive but was " + expectedBlocksInNonOBFTSlots
+              + " (floored=" + expectedBlocks
+              + ", slotsPerEpoch=" + networkConfig.getExpectedSlotsPerEpoch()
+              + ", activeSlotCoefficient=" + networkConfig.getActiveSlotCoefficient()
+              + ", decentralization=" + decentralizationParameter + ")");
+    }
+    BigInteger blocksMade = BigInteger.valueOf(totalBlocksInEpochByPools);
+    if (blocksMade.compareTo(expectedBlocks) >= 0) {
+      return Ratio.ONE;
+    }
 
     // eta is the ratio between the number of blocks that have been produced during the epoch, and
     // the expectation value of blocks that should have been produced during the epoch under
     // ideal conditions.
-    MathContext mathContext = new MathContext(32);
-    return new BigDecimal(totalBlocksInEpochByPools).divide(expectedBlocksInNonOBFTSlots, mathContext).min(BigDecimal.ONE);
+    return Ratio.of(blocksMade, expectedBlocks);
   }
 
   /*

--- a/calculation/src/main/java/org/cardanofoundation/rewards/calculation/util/Ratio.java
+++ b/calculation/src/main/java/org/cardanofoundation/rewards/calculation/util/Ratio.java
@@ -1,0 +1,94 @@
+package org.cardanofoundation.rewards.calculation.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Exact rational arithmetic for ledger calculations that need Haskell
+ * {@code Rational}-style behavior and a single explicit floor at the end.
+ */
+public final class Ratio {
+    public static final Ratio ZERO = new Ratio(BigInteger.ZERO, BigInteger.ONE);
+    public static final Ratio ONE = new Ratio(BigInteger.ONE, BigInteger.ONE);
+
+    private final BigInteger numerator;
+    private final BigInteger denominator;
+
+    private Ratio(BigInteger numerator, BigInteger denominator) {
+        if (denominator.signum() == 0) {
+            throw new IllegalArgumentException("Ratio denominator must not be zero");
+        }
+        if (numerator.signum() == 0) {
+            this.numerator = BigInteger.ZERO;
+            this.denominator = BigInteger.ONE;
+            return;
+        }
+
+        BigInteger normalizedNumerator = numerator;
+        BigInteger normalizedDenominator = denominator;
+        if (normalizedDenominator.signum() < 0) {
+            normalizedNumerator = normalizedNumerator.negate();
+            normalizedDenominator = normalizedDenominator.negate();
+        }
+
+        BigInteger gcd = normalizedNumerator.gcd(normalizedDenominator);
+        this.numerator = normalizedNumerator.divide(gcd);
+        this.denominator = normalizedDenominator.divide(gcd);
+    }
+
+    public static Ratio of(BigInteger numerator) {
+        return of(numerator, BigInteger.ONE);
+    }
+
+    public static Ratio of(BigInteger numerator, BigInteger denominator) {
+        return new Ratio(numerator, denominator);
+    }
+
+    public static Ratio from(BigDecimal value) {
+        BigDecimal normalized = value.stripTrailingZeros();
+        BigInteger numerator = normalized.unscaledValue();
+        int scale = normalized.scale();
+        if (scale < 0) {
+            return of(numerator.multiply(BigInteger.TEN.pow(-scale)), BigInteger.ONE);
+        }
+        return of(numerator, BigInteger.TEN.pow(scale));
+    }
+
+    public BigInteger numerator() {
+        return numerator;
+    }
+
+    public BigInteger denominator() {
+        return denominator;
+    }
+
+    public Ratio multiply(Ratio other) {
+        return of(numerator.multiply(other.numerator), denominator.multiply(other.denominator));
+    }
+
+    public Ratio subtract(Ratio other) {
+        return of(numerator.multiply(other.denominator).subtract(other.numerator.multiply(denominator)),
+                denominator.multiply(other.denominator));
+    }
+
+    public BigInteger floor() {
+        return floor(numerator, denominator);
+    }
+
+    public BigInteger multiplyAndFloor(BigInteger value) {
+        return floor(value.multiply(numerator), denominator);
+    }
+
+    @Override
+    public String toString() {
+        return numerator + "/" + denominator;
+    }
+
+    private static BigInteger floor(BigInteger numerator, BigInteger denominator) {
+        BigInteger[] quotientAndRemainder = numerator.divideAndRemainder(denominator);
+        if (numerator.signum() < 0 && quotientAndRemainder[1].signum() != 0) {
+            return quotientAndRemainder[0].subtract(BigInteger.ONE);
+        }
+        return quotientAndRemainder[0];
+    }
+}

--- a/calculation/src/test/java/org/cardanofoundation/rewards/calculation/TreasuryCalculationTest.java
+++ b/calculation/src/test/java/org/cardanofoundation/rewards/calculation/TreasuryCalculationTest.java
@@ -1,0 +1,108 @@
+package org.cardanofoundation.rewards.calculation;
+
+import org.cardanofoundation.rewards.calculation.config.NetworkConfig;
+import org.cardanofoundation.rewards.calculation.util.Ratio;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TreasuryCalculationTest {
+
+    @Test
+    void calculateTotalRewardPotWithEtaUsesExactRationalFloor() {
+        BigInteger rewardPot = TreasuryCalculation.calculateTotalRewardPotWithEta(
+                new BigDecimal("0.003"),
+                59,
+                BigDecimal.ZERO,
+                new BigInteger("35989500000000000"),
+                BigInteger.ZERO,
+                shortEpochConfig());
+
+        assertEquals(new BigInteger("106169025000000"), rewardPot);
+    }
+
+    @Test
+    void calculateTotalRewardPotWithEtaFloorsFractionalResult() {
+        BigInteger rewardPot = TreasuryCalculation.calculateTotalRewardPotWithEta(
+                new BigDecimal("0.003"),
+                59,
+                BigDecimal.ZERO,
+                BigInteger.valueOf(1000),
+                BigInteger.valueOf(7),
+                shortEpochConfig());
+
+        assertEquals(BigInteger.valueOf(9), rewardPot);
+    }
+
+    @Test
+    void calculateTotalRewardPotWithEtaUsesEtaOneWhenDecentralizationAtThreshold() {
+        BigInteger rewardPot = TreasuryCalculation.calculateTotalRewardPotWithEta(
+                new BigDecimal("0.003"),
+                0,
+                new BigDecimal("0.8"),
+                BigInteger.valueOf(1000),
+                BigInteger.ZERO,
+                shortEpochConfig());
+
+        assertEquals(BigInteger.valueOf(3), rewardPot);
+    }
+
+    @Test
+    void calculateTotalRewardPotWithEtaCapsEtaAtOneWhenBlocksMeetExpectation() {
+        BigInteger rewardPot = TreasuryCalculation.calculateTotalRewardPotWithEta(
+                new BigDecimal("0.003"),
+                60,
+                BigDecimal.ZERO,
+                BigInteger.valueOf(1000),
+                BigInteger.ZERO,
+                shortEpochConfig());
+
+        assertEquals(BigInteger.valueOf(3), rewardPot);
+    }
+
+    @Test
+    void calculateTotalRewardPotWithEtaReportsExpectedBlocksConfiguration() {
+        NetworkConfig networkConfig = NetworkConfig.builder()
+                .expectedSlotsPerEpoch(0)
+                .activeSlotCoefficient(1.0)
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                TreasuryCalculation.calculateTotalRewardPotWithEta(
+                        new BigDecimal("0.003"),
+                        1,
+                        new BigDecimal("0.79"),
+                        BigInteger.valueOf(1000),
+                        BigInteger.ZERO,
+                        networkConfig));
+
+        assertTrue(exception.getMessage().contains("slotsPerEpoch=0"));
+        assertTrue(exception.getMessage().contains("decentralization=0.79"));
+    }
+
+    @Test
+    void ratioMultiplyAndFloorUsesExactDecimalValue() {
+        BigInteger treasuryCut = Ratio.from(new BigDecimal("0.2"))
+                .multiplyAndFloor(new BigInteger("106169025000000"));
+
+        assertEquals(new BigInteger("21233805000000"), treasuryCut);
+    }
+
+    @Test
+    void ratioFloorHandlesNegativeRemainders() {
+        assertEquals(BigInteger.valueOf(-3), Ratio.of(BigInteger.valueOf(-7), BigInteger.valueOf(3)).floor());
+        assertEquals(BigInteger.valueOf(-3), Ratio.from(new BigDecimal("-0.2")).multiplyAndFloor(BigInteger.valueOf(11)));
+    }
+
+    private NetworkConfig shortEpochConfig() {
+        return NetworkConfig.builder()
+                .expectedSlotsPerEpoch(60)
+                .activeSlotCoefficient(1.0)
+                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,9 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
     </distributionManagement>
 
     <build>


### PR DESCRIPTION
 ## Summary

  Fix reward-pot and treasury-cut calculation to use exact rational arithmetic instead of finite `BigDecimal` eta division.

  The previous eta calculation rounded non-terminating ratios such as `59/60` before multiplying by reserves. When the exact result landed on an integer boundary, that truncation could push the value just below the boundary and lose 1 lovelace after flooring. 
  
Reproducible in YaciDevKit DevNet.

  ## Changes

  - Add `Ratio` for exact rational arithmetic.
  - Calculate eta as an exact ratio and floor only after the full reward-pot multiplication.
  - Use exact floor arithmetic for treasury cut.
  - Preserve Haskell ledger behavior for expected block calculation.
  - Add regression tests for:
    - devnet `59/60` boundary case
    - fractional reward-pot floor
    - eta cap at `1`
    - `d >= 0.8` eta shortcut
    - negative ratio floor behavior
