### PR TITLE
chore: migrate publishing from OSSRH to Maven Central Portal

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           java-version: '18'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}

--- a/calculation/.flattened-pom.xml
+++ b/calculation/.flattened-pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.cardanofoundation</groupId>
   <artifactId>cf-rewards-calculation</artifactId>
-  <version>0.11.1</version>
+  <version>1.0.1</version>
   <name>cardano-reward-calculation</name>
   <description>This project aims to be a cardano reward calculation, java formula implementation and edge case
         documentation</description>
@@ -36,25 +36,24 @@
     <url>https://github.com/cardano-foundation/cf-java-rewards-calculation/issues</url>
   </issueManagement>
   <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
   <properties>
     <version.lombok>1.18.30</version.lombok>
+    <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
     <version.flatten-maven-plugin>1.2.7</version.flatten-maven-plugin>
     <version.java>17</version.java>
     <version.slf4j>2.0.12</version.slf4j>
-    <maven.compiler.source>17</maven.compiler.source>
     <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
     <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
     <version.maven-site-plugin>4.0.0-M2</version.maven-site-plugin>
+    <version.central-publishing-plugin>0.9.0</version.central-publishing-plugin>
+    <version.junit-jupiter>5.10.2</version.junit-jupiter>
     <version.maven-project-info-reports-plugin>3.3.0</version.maven-project-info-reports-plugin>
   </properties>
   <dependencies>
@@ -79,6 +78,12 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-javadoc-plugin</artifactId>
       <version>${version.maven-javadoc-plugin}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -124,6 +129,10 @@
           <tagNameFormat>@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -131,6 +140,18 @@
       <id>ci-cd</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.central-publishing-plugin}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+              <deploymentName>${project.groupId}:${project.artifactId}-${project.version}</deploymentName>
+            </configuration>
+          </plugin>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>3.1.0</version>

--- a/calculation/pom.xml
+++ b/calculation/pom.xml
@@ -59,17 +59,14 @@
         <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
         <version.flatten-maven-plugin>1.2.7</version.flatten-maven-plugin>
         <version.maven-project-info-reports-plugin>3.3.0</version.maven-project-info-reports-plugin>
+        <version.central-publishing-plugin>0.9.0</version.central-publishing-plugin>
     </properties>
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
     </distributionManagement>
 
     <dependencies>
@@ -108,6 +105,18 @@
             <id>ci-cd</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${version.central-publishing-plugin}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <deploymentName>${project.groupId}:${project.artifactId}-${project.version}</deploymentName>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,9 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
     </distributionManagement>
 
     <build>


### PR DESCRIPTION
Replace the deprecated s01.oss.sonatype.org (OSSRH) publishing setup with the new Maven Central Portal (central.sonatype.com), following the cf-cardano-conversions-java reference.

- Point distributionManagement snapshot repos at the Central Portal and drop the OSSRH staging release repo
- Add central-publishing-maven-plugin (0.9.0) to the calculation ci-cd profile to handle upload and auto-publish
- Update publish workflow server-id from ossrh to central
- Regenerate calculation/.flattened-pom.xml